### PR TITLE
Fix contextmenu flash disappear issue in Firefox

### DIFF
--- a/lib/ext/menu.js
+++ b/lib/ext/menu.js
@@ -7,7 +7,8 @@ flowplayer(function(api, root) {
     var ui = common.find('.fp-ui', root)[0];
     common.toggleClass(menu, 'fp-active', true);
     setTimeout(function() {
-      bean.one(document, 'click', function() {
+      bean.off(document.body, 'click');
+      bean.one(document.body, 'click', function() {
         api.hideMenu(menu);
       });
     });


### PR DESCRIPTION
When triggering the right-click event on the player in Firefox, there's always a chance to have a flash disappear issue like the following gif:

![jun-04-2018 10-47-50](https://user-images.githubusercontent.com/7589350/40896127-eb6fc32c-67e5-11e8-80f9-44874009d3e7.gif)

When you opened the contextmenu, and oops it disappeared immediately after that.

I checked the codes, then i found something was wrong with the click event bound on the `document`. Maybe in the Firefox the contextmenu event will also trigger the events on `document`, which will not in the Chrome. Here's the code fragments:

```javascript
  api.showMenu = function(menu, triggerElement) {
    var ui = common.find('.fp-ui', root)[0];
    common.toggleClass(menu, 'fp-active', true);
    setTimeout(function() {
      // Always unbind the click event before bind another one to avoid multi-trigger after multi-times 
      // right-click actions.
      bean.off(document.body, 'click');
      // Change the click on document to document.body, which solves the flash issue.
      bean.one(document.body, 'click', function() {
        console.log('bean.one(document, click');
        api.hideMenu(menu);
      });
    });
```

And the well working version gif:

![jun-04-2018 10-49-12](https://user-images.githubusercontent.com/7589350/40896480-d88126d2-67e7-11e8-9f22-ac3a0834cc1a.gif)

===

Browser: 
> "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0"